### PR TITLE
Add note of `bc` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ MAKE_CONFIG=menuconfig bash GetPatchAndCompileKernel.sh
 ```
 
 Now, you need all the tools required to compile a kernel.  
-That includes, at least, `gcc`, `make`, `automake`, `bison` and `flex`.
+That includes, at least, `gcc`, `make`, `automake`, `bison`, `flex` and `bc`.
 
 Prebuilt kernels
 ----------------


### PR DESCRIPTION
Without `bc` installed on Arch Linux build fails:

```
  MKELF   scripts/mod/elfconfig.h                 
  HOSTCC  scripts/mod/modpost.o                   
  HOSTCC  scripts/mod/file2alias.o               
  HOSTCC  scripts/mod/sumversion.o             
  CC      kernel/bounds.s                       
/bin/sh: bc: command not found             
make[1]: *** [Kbuild:42: include/generated/timeconst.h] Error 127
make[1]: *** Waiting for unfinished jobs....          
  HOSTCC  scripts/dtc/fstree.o        
  HOSTCC  scripts/dtc/data.o 
  HOSTCC  scripts/dtc/livetree.o  
  HOSTCC  scripts/dtc/treesource.o
make: *** [Makefile:1081: prepare0] Error 2
make: *** Waiting for unfinished jobs....  
  HOSTCC  scripts/dtc/srcpos.o       
  HOSTCC  scripts/dtc/checks.o    
  HOSTCC  scripts/dtc/util.o               
  YACC    scripts/dtc/dtc-parser.tab.h
  LEX     scripts/dtc/dtc-lexer.lex.c               
  YACC    scripts/dtc/dtc-parser.tab.c               
  HOSTCC  scripts/dtc/dtc-parser.tab.o           
  HOSTCC  scripts/dtc/dtc-lexer.lex.o      
  HOSTLD  scripts/mod/modpost                    
  HOSTLD  scripts/dtc/dtc        
Compilation failed
```